### PR TITLE
Feat: 오늘의 문장

### DIFF
--- a/http/daily_sentence.http
+++ b/http/daily_sentence.http
@@ -8,6 +8,10 @@ Authorization: Bearer {{accessToken}}
   "mean": "특히 오늘날, 우리가 코로나19와 함께 생활하고 있기 때문에, 많은 식당, 카페, 그리고 기업체들은 입장하기 전에 고객에게 QR 코드를 보여주도록 요구합니다."
 }
 
+> {%
+    client.global.set("dailySentenceId", response.body.dailySentenceId)
+%}
+
 ### 오늘의 문장 전체 조회
 GET localhost:8088/daily-sentence
 Content-Type: application/json
@@ -35,7 +39,7 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 ### 오늘의 문장 수정 - 뜻
-PUT localhost:8088/daily-sentence/9
+PUT localhost:8088/daily-sentence/{{dailySentenceId}}
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -44,7 +48,7 @@ Authorization: Bearer {{accessToken}}
 }
 
 ### 오늘의 문장 수정 - 문장과 뜻
-PUT localhost:8088/daily-sentence/9
+PUT localhost:8088/daily-sentence/{{dailySentenceId}}
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -53,3 +57,7 @@ Authorization: Bearer {{accessToken}}
   "mean": "스마트폰이 없으면 사람이 이 코드를 보여줄 수 없어 입장하기가 어렵습니다1."
 }
 
+### 오늘의 문장 삭제
+DELETE localhost:8088/daily-sentence/{{dailySentenceId}}
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}

--- a/http/daily_sentence.http
+++ b/http/daily_sentence.http
@@ -4,6 +4,33 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 {
-  "sentence": "They try to put a malicious code in your smartphone and send an authorization code for the micropayment to them",
-  "mean": "그들은 당신의 스마트폰에 악성 코드를 주입하고 소액 결제에 필요한 인증 번호를 그들에게 전송시킨다."
+  "sentence": "Especially today, as we live with COVID-19, many restaurants, cafes, and businesses require customers to show a QR code before entering.",
+  "mean": "특히 오늘날, 우리가 코로나19와 함께 생활하고 있기 때문에, 많은 식당, 카페, 그리고 기업체들은 입장하기 전에 고객에게 QR 코드를 보여주도록 요구합니다."
 }
+
+### 오늘의 문장 전체 조회
+GET localhost:8088/daily-sentence
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### 오늘의 문장 연도 별 조회
+GET localhost:8088/daily-sentence?year=2024
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### 오늘의 문장 월별 조회
+GET localhost:8088/daily-sentence?year=2024&month=11
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+
+### 오늘의 문장 일별 조회
+GET localhost:8088/daily-sentence?year=2024&month=11&day=26
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### 오늘의 문장 주별 조회
+GET localhost:8088/daily-sentence?year=2024&month=11&week=4
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+

--- a/http/daily_sentence.http
+++ b/http/daily_sentence.http
@@ -1,0 +1,9 @@
+### 오늘의 문장 저장
+POST localhost:8088/daily-sentence
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "sentence": "They try to put a malicious code in your smartphone and send an authorization code for the micropayment to them",
+  "mean": "그들은 당신의 스마트폰에 악성 코드를 주입하고 소액 결제에 필요한 인증 번호를 그들에게 전송시킨다."
+}

--- a/http/daily_sentence.http
+++ b/http/daily_sentence.http
@@ -34,3 +34,22 @@ GET localhost:8088/daily-sentence?year=2024&month=11&week=4
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
+### 오늘의 문장 수정 - 뜻
+PUT localhost:8088/daily-sentence/9
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "mean": "오늘의 문장 뜻 수정"
+}
+
+### 오늘의 문장 수정 - 문장과 뜻
+PUT localhost:8088/daily-sentence/9
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+{
+  "sentence": "Without a smartphone, a person would be unable to show this code which would make it difficult for them to enter",
+  "mean": "스마트폰이 없으면 사람이 이 코드를 보여줄 수 없어 입장하기가 어렵습니다1."
+}
+

--- a/src/main/java/com/numo/wordapp/comm/exception/ErrorCode.java
+++ b/src/main/java/com/numo/wordapp/comm/exception/ErrorCode.java
@@ -34,6 +34,8 @@ public enum ErrorCode {
 
     SOUND_CANNOT_CREATED(4000, "사운드 파일 생성 중 오류가 발생했습니다.", "사운드 파일 생성 중 오류가 발생했습니다."),
     WORD_GROUP_EXISTS(3050, "해당하는 품사명이 이미 존재하므로 저장할 수 없습니다. 다른 이름으로 시도해주세요.", "해당 계정에 동일한 품사명이 존재하므로 저장이 불가합니다."),
+
+    DAILY_SENTENCE_NOT_FOUND(4000, "해당하는 오늘의 문장 데이터를 찾을 수 없습니다.", "해당하는 오늘의 문장 데이터가 없습니다"),
     ;
 
     private final int code;

--- a/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
+++ b/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
@@ -1,0 +1,28 @@
+package com.numo.wordapp.controller;
+
+import com.numo.wordapp.dto.sentence.DailySentenceRequestDto;
+import com.numo.wordapp.dto.sentence.DailySentenceDto;
+import com.numo.wordapp.security.service.UserDetailsImpl;
+import com.numo.wordapp.service.sentence.DailySentenceService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("daily-sentence")
+@RestController
+@RequiredArgsConstructor
+public class DailySentenceController {
+    private final DailySentenceService dailySentenceService;
+
+    @Operation(summary = "오늘의 문장 저장", description = "오늘의 문장을 저장한다")
+    @PostMapping
+    public ResponseEntity<DailySentenceDto> saveSentence(@AuthenticationPrincipal UserDetailsImpl user,
+                                                         @RequestBody DailySentenceRequestDto requestDto) {
+        return ResponseEntity.ok(dailySentenceService.saveSentence(user.getUserId(), requestDto));
+    }
+}

--- a/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
+++ b/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
@@ -1,17 +1,18 @@
 package com.numo.wordapp.controller;
 
-import com.numo.wordapp.dto.sentence.DailySentenceRequestDto;
 import com.numo.wordapp.dto.sentence.DailySentenceDto;
+import com.numo.wordapp.dto.sentence.DailySentenceParameterDto;
+import com.numo.wordapp.dto.sentence.DailySentenceRequestDto;
+import com.numo.wordapp.dto.sentence.ReadDailySentenceDto;
 import com.numo.wordapp.security.service.UserDetailsImpl;
 import com.numo.wordapp.service.sentence.DailySentenceService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("daily-sentence")
 @RestController
@@ -25,4 +26,12 @@ public class DailySentenceController {
                                                          @RequestBody DailySentenceRequestDto requestDto) {
         return ResponseEntity.ok(dailySentenceService.saveSentence(user.getUserId(), requestDto));
     }
+
+    @Operation(summary = "오늘의 문장 연도 별 조회", description = "오늘의 문장을 조회한다")
+    @GetMapping
+    public ResponseEntity<List<ReadDailySentenceDto>> getSentence(@AuthenticationPrincipal UserDetailsImpl user,
+                                                                  DailySentenceParameterDto parameterDto) {
+        return ResponseEntity.ok(dailySentenceService.getSentenceBy(user.getUserId(), parameterDto));
+    }
+
 }

--- a/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
+++ b/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
@@ -41,4 +41,12 @@ public class DailySentenceController {
                                                            @RequestBody DailySentenceRequestDto requestDto) {
         return ResponseEntity.ok(dailySentenceService.updateSentence(user.getUserId(), dailySentenceId, requestDto));
     }
+
+    @Operation(summary = "오늘의 문장 삭제", description = "오늘의 문장을 삭제한다")
+    @DeleteMapping("/{dailySentenceId}")
+    public ResponseEntity<Void> deleteSentence(@AuthenticationPrincipal UserDetailsImpl user,
+                                               @PathVariable("dailySentenceId") Long dailySentenceId) {
+        dailySentenceService.deleteSentence(user.getUserId(), dailySentenceId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
+++ b/src/main/java/com/numo/wordapp/controller/DailySentenceController.java
@@ -27,11 +27,18 @@ public class DailySentenceController {
         return ResponseEntity.ok(dailySentenceService.saveSentence(user.getUserId(), requestDto));
     }
 
-    @Operation(summary = "오늘의 문장 연도 별 조회", description = "오늘의 문장을 조회한다")
+    @Operation(summary = "오늘의 문장 조회", description = "오늘의 문장을 조회한다")
     @GetMapping
     public ResponseEntity<List<ReadDailySentenceDto>> getSentence(@AuthenticationPrincipal UserDetailsImpl user,
                                                                   DailySentenceParameterDto parameterDto) {
         return ResponseEntity.ok(dailySentenceService.getSentenceBy(user.getUserId(), parameterDto));
     }
 
+    @Operation(summary = "오늘의 문장 수정", description = "오늘의 문장을 수정한다")
+    @PutMapping("/{dailySentenceId}")
+    public ResponseEntity<DailySentenceDto> updateSentence(@AuthenticationPrincipal UserDetailsImpl user,
+                                                           @PathVariable("dailySentenceId") Long dailySentenceId,
+                                                           @RequestBody DailySentenceRequestDto requestDto) {
+        return ResponseEntity.ok(dailySentenceService.updateSentence(user.getUserId(), dailySentenceId, requestDto));
+    }
 }

--- a/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceDto.java
+++ b/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceDto.java
@@ -1,0 +1,37 @@
+package com.numo.wordapp.dto.sentence;
+
+import com.numo.wordapp.dto.word.DailyWordDto;
+import com.numo.wordapp.entity.sentence.DailySentence;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record DailySentenceDto(
+   Long dailySentenceId,
+   String sentence,
+   String mean,
+   int year,
+   int month,
+   int week,
+   int day,
+   List<DailyWordDto> words,
+   LocalDateTime createTime,
+   LocalDateTime updateTime
+) {
+    public static DailySentenceDto of(DailySentence dailySentence, List<DailyWordDto> words) {
+        return DailySentenceDto.builder()
+                .dailySentenceId(dailySentence.getDailySentenceId())
+                .sentence(dailySentence.getSentence())
+                .mean(dailySentence.getMean())
+                .year(dailySentence.getYear())
+                .month(dailySentence.getMonth())
+                .week(dailySentence.getWeek())
+                .day(dailySentence.getDay())
+                .words(words)
+                .createTime(dailySentence.getCreateTime())
+                .updateTime(dailySentence.getUpdateTime())
+                .build();
+    }
+}

--- a/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceDto.java
+++ b/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceDto.java
@@ -1,11 +1,9 @@
 package com.numo.wordapp.dto.sentence;
 
-import com.numo.wordapp.dto.word.DailyWordDto;
 import com.numo.wordapp.entity.sentence.DailySentence;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Builder
 public record DailySentenceDto(
@@ -16,11 +14,10 @@ public record DailySentenceDto(
    int month,
    int week,
    int day,
-   List<DailyWordDto> words,
    LocalDateTime createTime,
    LocalDateTime updateTime
 ) {
-    public static DailySentenceDto of(DailySentence dailySentence, List<DailyWordDto> words) {
+    public static DailySentenceDto of(DailySentence dailySentence) {
         return DailySentenceDto.builder()
                 .dailySentenceId(dailySentence.getDailySentenceId())
                 .sentence(dailySentence.getSentence())
@@ -29,7 +26,6 @@ public record DailySentenceDto(
                 .month(dailySentence.getMonth())
                 .week(dailySentence.getWeek())
                 .day(dailySentence.getDay())
-                .words(words)
                 .createTime(dailySentence.getCreateTime())
                 .updateTime(dailySentence.getUpdateTime())
                 .build();

--- a/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceParameterDto.java
+++ b/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceParameterDto.java
@@ -1,0 +1,9 @@
+package com.numo.wordapp.dto.sentence;
+
+public record DailySentenceParameterDto(
+        Integer year,
+        Integer month,
+        Integer day,
+        Integer week
+) {
+}

--- a/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceRequestDto.java
+++ b/src/main/java/com/numo/wordapp/dto/sentence/DailySentenceRequestDto.java
@@ -1,0 +1,18 @@
+package com.numo.wordapp.dto.sentence;
+
+import com.numo.wordapp.entity.sentence.DailySentence;
+import com.numo.wordapp.entity.user.User;
+
+public record DailySentenceRequestDto(
+        String sentence,
+        String mean
+) {
+    public DailySentence toEntity(Long userId) {
+        User user = User.builder().userId(userId).build();
+        return DailySentence.builder()
+                .user(user)
+                .sentence(sentence)
+                .mean(mean)
+                .build();
+    }
+}

--- a/src/main/java/com/numo/wordapp/dto/sentence/DailyWordDto.java
+++ b/src/main/java/com/numo/wordapp/dto/sentence/DailyWordDto.java
@@ -1,9 +1,10 @@
-package com.numo.wordapp.dto.word;
+package com.numo.wordapp.dto.sentence;
 
 import lombok.Builder;
 
 @Builder
 public record DailyWordDto(
+        Long wordDailyWordId,
         Long wordId,
         String word,
         String mean,

--- a/src/main/java/com/numo/wordapp/dto/sentence/ReadDailySentenceDto.java
+++ b/src/main/java/com/numo/wordapp/dto/sentence/ReadDailySentenceDto.java
@@ -1,0 +1,36 @@
+package com.numo.wordapp.dto.sentence;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record ReadDailySentenceDto(
+   Long dailySentenceId,
+   String sentence,
+   String mean,
+   int year,
+   int month,
+   int week,
+   int day,
+   List<DailyWordDto> dailyWords,
+   LocalDateTime createTime,
+   LocalDateTime updateTime
+) {
+    public static ReadDailySentenceDto of(DailySentenceDto dailySentenceDto, List<DailyWordDto> words) {
+        return ReadDailySentenceDto.builder()
+                .dailySentenceId(dailySentenceDto.dailySentenceId())
+                .sentence(dailySentenceDto.sentence())
+                .mean(dailySentenceDto.mean())
+                .year(dailySentenceDto.year())
+                .month(dailySentenceDto.month())
+                .week(dailySentenceDto.week())
+                .day(dailySentenceDto.day())
+                .dailyWords(words)
+                .createTime(dailySentenceDto.createTime())
+                .updateTime(dailySentenceDto.updateTime())
+                .build();
+    }
+
+}

--- a/src/main/java/com/numo/wordapp/dto/word/DailyWordDto.java
+++ b/src/main/java/com/numo/wordapp/dto/word/DailyWordDto.java
@@ -1,0 +1,13 @@
+package com.numo.wordapp.dto.word;
+
+import lombok.Builder;
+
+@Builder
+public record DailyWordDto(
+        Long wordId,
+        String word,
+        String mean,
+        Long folderId,
+        String folderName
+) {
+}

--- a/src/main/java/com/numo/wordapp/entity/sentence/DailySentence.java
+++ b/src/main/java/com/numo/wordapp/entity/sentence/DailySentence.java
@@ -1,5 +1,6 @@
 package com.numo.wordapp.entity.sentence;
 
+import com.numo.wordapp.dto.sentence.DailySentenceRequestDto;
 import com.numo.wordapp.entity.Timestamped;
 import com.numo.wordapp.entity.user.User;
 import com.numo.wordapp.entity.word.Word;
@@ -14,7 +15,9 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.WeekFields;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -48,7 +51,9 @@ public class DailySentence extends Timestamped {
     }
 
     public void setWordDailySentence(List<Word> words) {
-        wordDailySentences = new ArrayList<>();
+        if (wordDailySentences == null) {
+            wordDailySentences = new ArrayList<>();
+        }
         DailySentence dailySentence = this;
         for (Word word : words) {
             WordDailySentence wordDailySentence = new WordDailySentence(word, dailySentence);
@@ -76,5 +81,29 @@ public class DailySentence extends Timestamped {
         }
 
         return weekOfMonth;
+    }
+
+    public void update(DailySentenceRequestDto requestDto, List<Word> words) {
+        // 등록된 단어 데이터를 모두 삭제하고 새로 단어 데이터를 등록
+        this.sentence = requestDto.sentence();
+        this.mean = requestDto.mean();
+        removeDailyWords();
+        setWordDailySentence(words);
+    }
+
+    public void update(DailySentenceRequestDto requestDto) {
+        this.mean = requestDto.mean();
+    }
+
+    public boolean isCurrentSentenceEqual(String sentence) {
+        return Objects.equals(sentence, this.sentence);
+    }
+
+    public void removeDailyWords() {
+        Iterator<WordDailySentence> iterator = wordDailySentences.iterator();
+        while(iterator.hasNext()) {
+            iterator.next();
+            iterator.remove();
+        }
     }
 }

--- a/src/main/java/com/numo/wordapp/entity/sentence/DailySentence.java
+++ b/src/main/java/com/numo/wordapp/entity/sentence/DailySentence.java
@@ -1,0 +1,80 @@
+package com.numo.wordapp.entity.sentence;
+
+import com.numo.wordapp.entity.Timestamped;
+import com.numo.wordapp.entity.user.User;
+import com.numo.wordapp.entity.word.Word;
+import com.numo.wordapp.entity.word.WordDailySentence;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class DailySentence extends Timestamped {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long dailySentenceId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "dailySentence", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<WordDailySentence> wordDailySentences;
+
+    private String sentence;
+    private String mean;
+    private int year;
+    private int month;
+    private int week;
+    private int day;
+
+    @Builder
+    public DailySentence(Long dailySentenceId, User user, String sentence, String mean) {
+        this.dailySentenceId = dailySentenceId;
+        this.user = user;
+        this.sentence = sentence;
+        this.mean = mean;
+        setDate();
+    }
+
+    public void setWordDailySentence(List<Word> words) {
+        wordDailySentences = new ArrayList<>();
+        DailySentence dailySentence = this;
+        for (Word word : words) {
+            WordDailySentence wordDailySentence = new WordDailySentence(word, dailySentence);
+            wordDailySentences.add(wordDailySentence);
+        }
+    }
+
+    private void setDate() {
+        LocalDate localDate = LocalDate.now();
+        this.year = localDate.getYear();
+        this.month = localDate.getMonthValue();
+        this.day = localDate.getDayOfMonth();
+        this.week = getCurrentWeekOfMonth(localDate);
+    }
+
+    private int getCurrentWeekOfMonth(LocalDate localDate) {
+        // 한 주의 시작은 월요일이고, 첫 주에 4일이 포함되어있어야 첫 주 취급 (목/금/토/일)
+        WeekFields weekFields = WeekFields.of(DayOfWeek.MONDAY, 4);
+
+        int weekOfMonth = localDate.get(weekFields.weekOfMonth());
+
+        // 첫 주에 해당하지 않는 주의 경우 1주차로 계산
+        if (weekOfMonth == 0) {
+            weekOfMonth++;
+        }
+
+        return weekOfMonth;
+    }
+}

--- a/src/main/java/com/numo/wordapp/entity/word/Word.java
+++ b/src/main/java/com/numo/wordapp/entity/word/Word.java
@@ -46,8 +46,12 @@ public class Word extends Timestamped {
     @JoinColumn(name = "folder_id")
     private Folder folder;
 
-    @OneToMany(mappedBy = "word", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "word", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<WordDetail> wordDetails = new ArrayList<>();
+
+    // 오늘의 문장 추가
+    @OneToMany(mappedBy = "word")
+    private List<WordDailySentence> wordDailySentences;
 
     public void setWordDetails() {
         addWordDetails(wordDetails);
@@ -129,4 +133,5 @@ public class Word extends Timestamped {
         }
         return folder;
     }
+
 }

--- a/src/main/java/com/numo/wordapp/entity/word/WordDailySentence.java
+++ b/src/main/java/com/numo/wordapp/entity/word/WordDailySentence.java
@@ -1,0 +1,30 @@
+package com.numo.wordapp.entity.word;
+
+import com.numo.wordapp.entity.sentence.DailySentence;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class WordDailySentence {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "word_id")
+    private Word word;
+
+    @ManyToOne
+    @JoinColumn(name = "daily_sentence_id")
+    private DailySentence dailySentence;
+
+    public WordDailySentence(Word word, DailySentence dailySentence) {
+        this.word = word;
+        this.dailySentence = dailySentence;
+    }
+
+}

--- a/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepository.java
+++ b/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepository.java
@@ -1,0 +1,11 @@
+package com.numo.wordapp.repository.sentence;
+
+import com.numo.wordapp.dto.sentence.DailySentenceDto;
+import com.numo.wordapp.dto.sentence.DailySentenceParameterDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
+import java.util.List;
+
+public interface DailySentenceCustomRepository {
+    List<DailySentenceDto> findDailySentencesBy(Long userId, DailySentenceParameterDto parameterDto);
+    List<DailyWordDto> findDailyWordsBy(List<Long> sentenceIds);
+}

--- a/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepositoryImpl.java
+++ b/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepositoryImpl.java
@@ -1,0 +1,108 @@
+package com.numo.wordapp.repository.sentence;
+
+import com.numo.wordapp.dto.sentence.DailySentenceDto;
+import com.numo.wordapp.dto.sentence.DailySentenceParameterDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
+import com.numo.wordapp.entity.sentence.QDailySentence;
+import com.numo.wordapp.entity.word.QWordDailySentence;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class DailySentenceCustomRepositoryImpl implements DailySentenceCustomRepository {
+    private final JPAQueryFactory queryFactory;
+    QDailySentence qDailySentence = QDailySentence.dailySentence;
+
+    /**
+     * 연도, 월, 일, 주별 문장 데이터 조회
+     * parameterDto에 값이 없으면 해당하는 모든 유저 문장 데이터를 조회
+     *
+     * @param userId 유저 아이디
+     * @param parameterDto 연도, 월, 일, 주별 데이터
+     * @return 조회된 연도, 월, 일, 주별 문장 데이터 조회
+     */
+    @Override
+    public List<DailySentenceDto> findDailySentencesBy(Long userId, DailySentenceParameterDto parameterDto) {
+        List<DailySentenceDto> result = queryFactory.select(
+                        Projections.constructor(
+                                DailySentenceDto.class,
+                                qDailySentence.dailySentenceId,
+                                qDailySentence.sentence,
+                                qDailySentence.mean,
+                                qDailySentence.year,
+                                qDailySentence.month,
+                                qDailySentence.week,
+                                qDailySentence.day,
+                                qDailySentence.createTime,
+                                qDailySentence.updateTime
+                        ))
+                .from(qDailySentence)
+                .where(
+                        qDailySentence.user.userId.eq(userId),
+                        createDailySentenceCondition(parameterDto)
+                )
+                .fetch();
+        return result;
+    }
+
+    /**
+     * 파라미터에 해당하는 쿼리 조건문을 만든다
+     * @param parameterDto 조건문에 들어갈 필드 값
+     * @return 파라미터에 해당하는 쿼리 조건문
+     */
+    private BooleanExpression createDailySentenceCondition(DailySentenceParameterDto parameterDto) {
+        BooleanExpression result = Expressions.asString("1").eq("1");
+        Integer year = parameterDto.year();
+        Integer month = parameterDto.month();
+        Integer day = parameterDto.day();
+        Integer week = parameterDto.week();
+
+        if (year != null) {
+            result = result.and(qDailySentence.year.eq(year));
+        }
+
+        if (month != null) {
+            result = result.and(qDailySentence.month.eq(month));
+        }
+
+        if (day != null) {
+            result = result.and(qDailySentence.day.eq(day));
+        }
+
+        if (week != null) {
+            result = result.and(qDailySentence.week.eq(week));
+        }
+
+        return result;
+    }
+
+    /**
+     * 문장 고유번호 리스트에 연관된 단어 조회
+     * @param sentenceIds 문장 고유번호 리스트
+     * @return 문장 고유번호 리스트에 연관된 단어 데이터
+     */
+    public List<DailyWordDto> findDailyWordsBy(List<Long> sentenceIds) {
+        QWordDailySentence qWordDailySentence = QWordDailySentence.wordDailySentence;
+        List<DailyWordDto> result = queryFactory.select(Projections.constructor(
+                DailyWordDto.class,
+                qWordDailySentence.dailySentence.dailySentenceId,
+                qWordDailySentence.word.wordId,
+                qWordDailySentence.word.word,
+                qWordDailySentence.word.mean,
+                qWordDailySentence.word.folder.folderId,
+                qWordDailySentence.word.folder.folderName
+                ))
+                .from(qWordDailySentence)
+                .leftJoin(qWordDailySentence.word)
+                .where(
+                        qWordDailySentence.dailySentence.dailySentenceId.in(sentenceIds)
+                )
+                .fetch();
+        return result;
+    }
+}

--- a/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceRepository.java
+++ b/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceRepository.java
@@ -3,5 +3,5 @@ package com.numo.wordapp.repository.sentence;
 import com.numo.wordapp.entity.sentence.DailySentence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DailySentenceRepository extends JpaRepository<DailySentence, Long> {
+public interface DailySentenceRepository extends JpaRepository<DailySentence, Long>, DailySentenceCustomRepository {
 }

--- a/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceRepository.java
+++ b/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceRepository.java
@@ -1,7 +1,18 @@
 package com.numo.wordapp.repository.sentence;
 
+import com.numo.wordapp.comm.exception.CustomException;
+import com.numo.wordapp.comm.exception.ErrorCode;
 import com.numo.wordapp.entity.sentence.DailySentence;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DailySentenceRepository extends JpaRepository<DailySentence, Long>, DailySentenceCustomRepository {
+    Optional<DailySentence> findByDailySentenceIdAndUser_UserId(Long dailySentenceId, Long userId);
+
+    default DailySentence findDailySentenceBy(Long dailySentenceId, Long userId) {
+        return findByDailySentenceIdAndUser_UserId(dailySentenceId, userId).orElseThrow(
+                () -> new CustomException(ErrorCode.DAILY_SENTENCE_NOT_FOUND)
+        );
+    }
 }

--- a/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceRepository.java
+++ b/src/main/java/com/numo/wordapp/repository/sentence/DailySentenceRepository.java
@@ -1,0 +1,7 @@
+package com.numo.wordapp.repository.sentence;
+
+import com.numo.wordapp.entity.sentence.DailySentence;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailySentenceRepository extends JpaRepository<DailySentence, Long> {
+}

--- a/src/main/java/com/numo/wordapp/repository/word/WordRepositoryCustom.java
+++ b/src/main/java/com/numo/wordapp/repository/word/WordRepositoryCustom.java
@@ -1,9 +1,12 @@
 package com.numo.wordapp.repository.word;
 
+import com.numo.wordapp.dto.word.DailyWordDto;
 import com.numo.wordapp.dto.word.ReadWordRequestDto;
 import com.numo.wordapp.entity.word.Word;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+
+import java.util.List;
 
 public interface WordRepositoryCustom {
     /**
@@ -13,4 +16,5 @@ public interface WordRepositoryCustom {
      *
      * */
     Slice<Word> findWordBy(Pageable pageable, Long userId, Long lastWordId, ReadWordRequestDto readDto);
+    List<DailyWordDto> findDailyWordBy(Long userId, List<String> words);
 }

--- a/src/main/java/com/numo/wordapp/repository/word/WordRepositoryCustom.java
+++ b/src/main/java/com/numo/wordapp/repository/word/WordRepositoryCustom.java
@@ -1,6 +1,6 @@
 package com.numo.wordapp.repository.word;
 
-import com.numo.wordapp.dto.word.DailyWordDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
 import com.numo.wordapp.dto.word.ReadWordRequestDto;
 import com.numo.wordapp.entity.word.Word;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/numo/wordapp/repository/word/WordRepositoryImpl.java
+++ b/src/main/java/com/numo/wordapp/repository/word/WordRepositoryImpl.java
@@ -1,6 +1,6 @@
 package com.numo.wordapp.repository.word;
 
-import com.numo.wordapp.dto.word.DailyWordDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
 import com.numo.wordapp.dto.word.ReadWordRequestDto;
 import com.numo.wordapp.entity.word.GttsCode;
 import com.numo.wordapp.entity.word.QWord;
@@ -63,6 +63,7 @@ public class WordRepositoryImpl implements WordRepositoryCustom {
     public List<DailyWordDto> findDailyWordBy(Long userId, List<String> words) {
         List<DailyWordDto> results = queryFactory.select(Projections.constructor(
                         DailyWordDto.class,
+                        qWord.wordId,
                         qWord.wordId,
                         qWord.word,
                         qWord.mean,

--- a/src/main/java/com/numo/wordapp/repository/word/WordRepositoryImpl.java
+++ b/src/main/java/com/numo/wordapp/repository/word/WordRepositoryImpl.java
@@ -1,10 +1,12 @@
 package com.numo.wordapp.repository.word;
 
+import com.numo.wordapp.dto.word.DailyWordDto;
 import com.numo.wordapp.dto.word.ReadWordRequestDto;
 import com.numo.wordapp.entity.word.GttsCode;
 import com.numo.wordapp.entity.word.QWord;
 import com.numo.wordapp.entity.word.Word;
 import com.numo.wordapp.entity.word.detail.QWordDetail;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -49,6 +51,49 @@ public class WordRepositoryImpl implements WordRepositoryCustom {
                 .limit(pageable.getPageSize()+1)
                 .fetch();
         return checkLastPage(pageable, results);
+    }
+
+    /**
+     * word 리스트에 해당하는 단어를 모두 찾는다.
+     * @param userId 유저 아이디
+     * @param words 찾을 단어 리스트
+     * @return 단어와 단어장 데이터 리스트(detail 포함x)
+     */
+    @Override
+    public List<DailyWordDto> findDailyWordBy(Long userId, List<String> words) {
+        List<DailyWordDto> results = queryFactory.select(Projections.constructor(
+                        DailyWordDto.class,
+                        qWord.wordId,
+                        qWord.word,
+                        qWord.mean,
+                        qWord.folder.folderId,
+                        qWord.folder.folderName
+                ))
+                .from(qWord)
+                .leftJoin(qWord.folder)
+                .where(
+                        qWord.user.userId.eq(userId),
+                        eqWords(words)
+                )
+                .fetch();
+        return results;
+    }
+
+    /**
+     * 단어들이 있는지 확인하기 위해 or 조건문을 만든다.
+     * @param words 단어 리스트
+     * @return 단어들을 확인하는 or 조건문
+     */
+    private BooleanExpression eqWords(List<String> words) {
+        BooleanExpression result = null;
+        for (String s : words) {
+            if (result == null) {
+                result = qWord.word.eq(s);
+                continue;
+            }
+            result = result.or(qWord.word.eq(s));
+        }
+        return result;
     }
 
     /**

--- a/src/main/java/com/numo/wordapp/service/sentence/DailySentenceService.java
+++ b/src/main/java/com/numo/wordapp/service/sentence/DailySentenceService.java
@@ -56,7 +56,7 @@ public class DailySentenceService {
      * 문장이 변경되면 연관된 단어 모두 삭제 후 다시 등록
      *
      * @param userId 유저 아이디
-     * @param dailySentenceId 수정할 문장 고유번호
+     * @param dailySentenceId 문장 고유번호
      * @param requestDto 수정할 내용
      * @return 수정한 문장 데이터
      */
@@ -74,6 +74,17 @@ public class DailySentenceService {
         // 등록된 단어 데이터를 모두 삭제하고 새로 단어 데이터를 등록
         dailySentence.update(requestDto, dailyWords);
         return DailySentenceDto.of(dailySentence);
+    }
+
+    /**
+     * 연관된 오늘의 단어 데이터와 함께 문장을 삭제한다
+     * @param userId 유저 아이디
+     * @param dailySentenceId 문장 고유번호
+     */
+    public void deleteSentence(Long userId, Long dailySentenceId) {
+        DailySentence dailySentence = dailySentenceRepository.findDailySentenceBy(dailySentenceId, userId);
+        dailySentence.removeDailyWords();
+        dailySentenceRepository.delete(dailySentence);
     }
 
     /**

--- a/src/main/java/com/numo/wordapp/service/sentence/DailySentenceService.java
+++ b/src/main/java/com/numo/wordapp/service/sentence/DailySentenceService.java
@@ -1,0 +1,47 @@
+package com.numo.wordapp.service.sentence;
+
+import com.numo.wordapp.dto.sentence.DailySentenceDto;
+import com.numo.wordapp.dto.sentence.DailySentenceRequestDto;
+import com.numo.wordapp.dto.word.DailyWordDto;
+import com.numo.wordapp.entity.sentence.DailySentence;
+import com.numo.wordapp.entity.word.Word;
+import com.numo.wordapp.repository.sentence.DailySentenceRepository;
+import com.numo.wordapp.service.word.WordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DailySentenceService {
+    private final DailySentenceRepository dailySentenceRepository;
+    private final WordService wordService;
+
+    /**
+     * 문장 입력 시 문장을 스페이스바를 기준으로 나누어 단어로 쪼갠 뒤
+     * 해당하는 단어가 자신의 단어장에 저장되어 있다면 정보를 저장함
+     * @param userId 유저 아이디
+     * @param requestDto 저장할 문장
+     * @return 자신의 단어장에 저장되어 있는 정보가 포함된 저장한 문장 데이터
+     */
+    public DailySentenceDto saveSentence(Long userId, DailySentenceRequestDto requestDto) {
+        DailySentence sentence = requestDto.toEntity(userId);
+        // 단어를 쪼갠다
+        List<String> words = splitSentence(requestDto.sentence());
+
+        List<DailyWordDto> dailyWordsDto = wordService.findDailyWord(userId, words);
+        List<Word> dailyWords = dailyWordsDto.stream().map(
+                dailyWordDto -> Word.builder().wordId(dailyWordDto.wordId()).build())
+                .toList();
+        sentence.setWordDailySentence(dailyWords);
+        return DailySentenceDto.of(dailySentenceRepository.save(sentence), dailyWordsDto);
+    }
+
+    private List<String> splitSentence(String sentence) {
+        String[] words = sentence.split(" ");
+        return Arrays.stream(words).toList();
+    }
+
+}

--- a/src/main/java/com/numo/wordapp/service/word/WordService.java
+++ b/src/main/java/com/numo/wordapp/service/word/WordService.java
@@ -5,6 +5,7 @@ import com.numo.wordapp.comm.exception.ErrorCode;
 import com.numo.wordapp.comm.util.ProcessBuilderUtil;
 import com.numo.wordapp.conf.PropertyConfig;
 import com.numo.wordapp.dto.page.PageDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
 import com.numo.wordapp.dto.word.*;
 import com.numo.wordapp.entity.word.GttsCode;
 import com.numo.wordapp.entity.word.Sound;

--- a/src/main/java/com/numo/wordapp/service/word/WordService.java
+++ b/src/main/java/com/numo/wordapp/service/word/WordService.java
@@ -112,6 +112,17 @@ public class WordService {
     }
 
     /**
+     * 해당하는 단어들을 포함하고 있는 단어 정보를 가져온다.
+     * 단어 상세정보는 가져오지 않는다.
+     * @param userId 유저 아이디
+     * @param words 검색할 단어 리스트
+     * @return 해당하는 단어들의 간단한 단어 정보(뜻, 단어, 단어장 정보 등)
+     */
+    public List<DailyWordDto> findDailyWord(Long userId, List<String> words) {
+        return wordRepository.findDailyWordBy(userId, words);
+    }
+
+    /**
      * 해당하는 단어의 음성파일이 없으면 파일 생성 및 데이터베이스에 해당하는 파일명을 저장한다.
      * @param wordName 단어명
      * */

--- a/src/test/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepositoryImplTest.java
+++ b/src/test/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepositoryImplTest.java
@@ -4,10 +4,12 @@ import com.numo.wordapp.dto.sentence.DailySentenceDto;
 import com.numo.wordapp.dto.sentence.DailySentenceParameterDto;
 import com.numo.wordapp.dto.sentence.DailyWordDto;
 import com.numo.wordapp.dto.sentence.ReadDailySentenceDto;
+import com.numo.wordapp.entity.sentence.DailySentence;
 import com.numo.wordapp.service.sentence.DailySentenceService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 
 import java.util.List;
 
@@ -53,5 +55,17 @@ class DailySentenceCustomRepositoryImplTest {
 
         List<ReadDailySentenceDto> res = dailySentenceService.getSentenceBy(userId, dto);
         System.out.println(res);
+    }
+
+    @Test
+//    @Transactional
+    @Rollback(value = false)
+    void find() {
+        Long userId = 2L;
+        Long dailySentenceId = 7L;
+
+        DailySentence dailySentence = dailySentenceRepository.findById(dailySentenceId).orElse(null);
+        dailySentence.removeDailyWords();
+        System.out.println(dailySentence);
     }
 }

--- a/src/test/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepositoryImplTest.java
+++ b/src/test/java/com/numo/wordapp/repository/sentence/DailySentenceCustomRepositoryImplTest.java
@@ -1,0 +1,57 @@
+package com.numo.wordapp.repository.sentence;
+
+import com.numo.wordapp.dto.sentence.DailySentenceDto;
+import com.numo.wordapp.dto.sentence.DailySentenceParameterDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
+import com.numo.wordapp.dto.sentence.ReadDailySentenceDto;
+import com.numo.wordapp.service.sentence.DailySentenceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class DailySentenceCustomRepositoryImplTest {
+
+    @Autowired
+    DailySentenceRepository dailySentenceRepository;
+
+    @Autowired
+    DailySentenceService dailySentenceService;
+
+    @Test
+    void findDailySentencesBy() {
+        Long userId = 2L;
+        DailySentenceParameterDto dto = new DailySentenceParameterDto(
+                null,
+                null,
+                null,
+                null
+        );
+
+        List<DailySentenceDto> dailySentencesBy = dailySentenceRepository.findDailySentencesBy(userId, dto);
+        System.out.println(dailySentencesBy);
+    }
+
+    @Test
+    void findDailyWordsBy() {
+        List<Long> sentenceIds = List.of(7L, 8L);
+        List<DailyWordDto> dailyWords = dailySentenceRepository.findDailyWordsBy(sentenceIds);
+        System.out.println(dailyWords);
+    }
+
+    @Test
+    void getSentenceBy() {
+        Long userId = 2L;
+        DailySentenceParameterDto dto = new DailySentenceParameterDto(
+                null,
+                null,
+                null,
+                null
+        );
+
+        List<ReadDailySentenceDto> res = dailySentenceService.getSentenceBy(userId, dto);
+        System.out.println(res);
+    }
+}

--- a/src/test/java/com/numo/wordapp/repository/word/WordRepositoryImplTest.java
+++ b/src/test/java/com/numo/wordapp/repository/word/WordRepositoryImplTest.java
@@ -1,0 +1,24 @@
+package com.numo.wordapp.repository.word;
+
+import com.numo.wordapp.dto.word.DailyWordDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+class WordRepositoryImplTest {
+
+    @Autowired
+    WordRepository wordRepository;
+
+    @Test
+    void findByWords() {
+        Long userId = 2L;
+        List<String> words = List.of("hello", "world", "word", "exception");
+        List<DailyWordDto> result = wordRepository.findDailyWordBy(userId, words);
+        Assertions.assertEquals("word", result.get(0).word());
+    }
+}

--- a/src/test/java/com/numo/wordapp/repository/word/WordRepositoryImplTest.java
+++ b/src/test/java/com/numo/wordapp/repository/word/WordRepositoryImplTest.java
@@ -1,6 +1,6 @@
 package com.numo.wordapp.repository.word;
 
-import com.numo.wordapp.dto.word.DailyWordDto;
+import com.numo.wordapp.dto.sentence.DailyWordDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/com/numo/wordapp/test/calendar/LocalDateTest.java
+++ b/src/test/java/com/numo/wordapp/test/calendar/LocalDateTest.java
@@ -1,0 +1,31 @@
+package com.numo.wordapp.test.calendar;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+
+public class LocalDateTest {
+    public static String getCurrentWeekOfMonth(LocalDate localDate) {
+        // 한 주의 시작은 월요일이고, 첫 주에 4일이 포함되어있어야 첫 주 취급 (목/금/토/일)
+        WeekFields weekFields = WeekFields.of(DayOfWeek.MONDAY, 4);
+
+        int weekOfMonth = localDate.get(weekFields.weekOfMonth());
+
+        // 첫 주에 해당하지 않는 주의 경우 1주차로 계산
+        if (weekOfMonth == 0) {
+            weekOfMonth++;
+        }
+
+        return localDate.getMonthValue() + "월 " + weekOfMonth + "주차";
+    }
+
+    @Test
+    void weekOfMonth() {
+        LocalDate date = LocalDate.now();
+        date = LocalDate.of(2024, 6,30);
+
+        System.out.println(getCurrentWeekOfMonth(date));
+    }
+}


### PR DESCRIPTION
#13 
매 일 문장과 뜻을 입력할 수 있는 기능
- 하루에 여러 문장 입력 가능
- 기간 별(연도, 월, 주, 일) 조회
- 연관된 단어 데이터 조회
- 입력한 문장의 단어 중 이미 입력된 단어장 데이터가 있다면 같이 조회
- 오늘의 문장 수정
  - 뜻만 수정: 문장의 연관된 단어 데이터 수정 없이 뜻만 수정
  - 문장 수정: 문장의 연관된 단어 데이터 전부 삭제 후 다시 조회 및 등록
- 오늘의 문장 삭제
연관된 단어 데이터 삭제는 실제 단어 데이터가 아닌 **연관 테이블 삭제**임