### PR TITLE
fix: 프론트에서 토큰 값을 받을 수 없는 문제 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 
     implementation 'com.auth0:java-jwt:4.4.0'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.6'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.6'
 

--- a/src/main/java/com/numo/wordapp/conf/PropertyConfig.java
+++ b/src/main/java/com/numo/wordapp/conf/PropertyConfig.java
@@ -13,6 +13,8 @@ public class PropertyConfig {
     private String processPath;
     @Value("${cstm.file.path}")
     private String storagePath;
+    @Value("${CLIENT_HOST}")
+    private String clientHost;
 
     public String getProcessPath() {
         if (processPath.endsWith("/")) {

--- a/src/main/java/com/numo/wordapp/controller/AuthController.java
+++ b/src/main/java/com/numo/wordapp/controller/AuthController.java
@@ -36,4 +36,5 @@ public class AuthController {
         authService.logout(user.getUserId());
         return ResponseEntity.noContent().build();
     }
+
 }

--- a/src/main/java/com/numo/wordapp/security/conf/SecurityConfig.java
+++ b/src/main/java/com/numo/wordapp/security/conf/SecurityConfig.java
@@ -1,9 +1,11 @@
 package com.numo.wordapp.security.conf;
 
+import com.numo.wordapp.conf.PropertyConfig;
 import com.numo.wordapp.security.handle.JwtAccessDeniedHandler;
 import com.numo.wordapp.security.handle.JwtAuthenticationEntryPoint;
 import com.numo.wordapp.security.jwt.JwtFilter;
 import com.numo.wordapp.security.jwt.TokenProvider;
+import com.numo.wordapp.security.oauth2.CommonLoginFailureHandler;
 import com.numo.wordapp.security.oauth2.CommonLoginSuccessHandler;
 import com.numo.wordapp.service.user.RefreshTokenService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +39,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final RefreshTokenService refreshTokenService;
+    private final PropertyConfig propertyConfig;
 
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
@@ -46,7 +49,11 @@ public class SecurityConfig {
     }
 
     public CommonLoginSuccessHandler commonLoginSuccessHandler() {
-        return new CommonLoginSuccessHandler(tokenProvider, refreshTokenService);
+        return new CommonLoginSuccessHandler(tokenProvider, refreshTokenService, propertyConfig);
+    }
+
+    public CommonLoginFailureHandler commonLoginFailureHandler() {
+        return new CommonLoginFailureHandler();
     }
 
     @Bean
@@ -76,6 +83,7 @@ public class SecurityConfig {
                 .redirectionEndpoint(redirectionEndpointConfig -> redirectionEndpointConfig
                         .baseUri("/oauth2/callback/*"))
                 .successHandler(commonLoginSuccessHandler())
+                .failureHandler(commonLoginFailureHandler())
                 .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
                         .userService(CustomOAuth2UserService))
         );

--- a/src/main/java/com/numo/wordapp/security/oauth2/CommonLoginFailureHandler.java
+++ b/src/main/java/com/numo/wordapp/security/oauth2/CommonLoginFailureHandler.java
@@ -1,0 +1,29 @@
+package com.numo.wordapp.security.oauth2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numo.wordapp.comm.response.CommonResult;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CommonLoginFailureHandler implements AuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        ObjectMapper mapper = new ObjectMapper();
+        CommonResult result = new CommonResult(
+                false,
+                401,
+                "소셜 로그인 중 에러가 발생했습니다.",
+                null
+        );
+        String res = mapper.writeValueAsString(result);
+
+        response.setContentType("application/json; charset=UTF-8");
+        response.getWriter().write(res);
+    }
+}

--- a/src/main/java/com/numo/wordapp/security/oauth2/CommonLoginSuccessHandler.java
+++ b/src/main/java/com/numo/wordapp/security/oauth2/CommonLoginSuccessHandler.java
@@ -1,11 +1,12 @@
 package com.numo.wordapp.security.oauth2;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.numo.wordapp.conf.PropertyConfig;
 import com.numo.wordapp.dto.user.TokenDto;
 import com.numo.wordapp.security.jwt.TokenProvider;
 import com.numo.wordapp.security.service.UserDetailsImpl;
 import com.numo.wordapp.service.user.RefreshTokenService;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,8 @@ import java.io.IOException;
 public class CommonLoginSuccessHandler implements AuthenticationSuccessHandler {
     private final TokenProvider tokenProvider;
     private final RefreshTokenService refreshTokenService;
+    private final PropertyConfig propertyConfig;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
@@ -25,10 +28,18 @@ public class CommonLoginSuccessHandler implements AuthenticationSuccessHandler {
         TokenDto tokenDto = tokenProvider.createTokenDto(userDetails.getUsername(), userDetails.getAuthorityList());
         refreshTokenService.saveOrUpdateToken(userDetails.getUserId(), tokenDto.refreshToken());
 
-        ObjectMapper mapper = new ObjectMapper();
-        String res = mapper.writeValueAsString(tokenDto);
+        Cookie accessToken = new Cookie("accessToken", tokenDto.accessToken());
+        Cookie refreshToken = new Cookie("refreshToken", tokenDto.refreshToken());
 
-        response.setContentType("application/json; charset=UTF-8");
-        response.getWriter().write(res);
+        accessToken.setPath("/");
+        refreshToken.setPath("/");
+        accessToken.setHttpOnly(true);
+        refreshToken.setHttpOnly(true);
+
+        response.addCookie(accessToken);
+        response.addCookie(refreshToken);
+
+        String clientHost = propertyConfig.getClientHost();
+        response.sendRedirect(clientHost+ "/oauth/callback");
     }
 }


### PR DESCRIPTION
#15 

- 프론트에서 xhr이 아닌 redirect를 통해 토큰 값을 받아야 하므로 이전과 같은 구조로는 로그인 이후 프론트에서 redirect를 해줄 수 없는 문제가 나타남
- xhr을 통해 토큰 값을 받아야 했기에 oauth2 인증 완료 이후 클라이언트의 url로 직접 리다이렉트
- 토큰 값 전송을 위해 쿠키 사용