### PR TITLE
feat: 사전 검색 api 추가

### DIFF
--- a/http/dict.http
+++ b/http/dict.http
@@ -1,4 +1,9 @@
 ### 사전 조회
-GET localhost:8088/dict/exceptionally
+GET localhost:8088/dict/exception
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
+
+### 사전 조회 (자동완성)
+GET localhost:8088/dict/list/exception
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}

--- a/http/dict.http
+++ b/http/dict.http
@@ -4,6 +4,6 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 ### 사전 조회 (자동완성)
-GET localhost:8088/dict/list/exception
+GET localhost:8088/dict/list/Pneumonoultramicroscopicsilicovolcanoconiosis
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}

--- a/http/word.http
+++ b/http/word.http
@@ -4,13 +4,13 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 {
-  "word": "exceptionally",
+  "word": "Pneumonoultramicroscopicsilicovolcanoconiosis",
   "mean": "mean",
   "read": "read",
   "memo": "memo",
   "memorization": "N",
   "details": [{
-    "wordGroupId": 12,
+    "wordGroupId": 24,
     "title": "title1",
     "content": "content1"
   }, {

--- a/src/main/java/com/numo/wordapp/controller/DictionaryController.java
+++ b/src/main/java/com/numo/wordapp/controller/DictionaryController.java
@@ -1,6 +1,8 @@
 package com.numo.wordapp.controller;
 
+import com.numo.wordapp.dto.dictionary.DictionaryCrawlingDto;
 import com.numo.wordapp.dto.dictionary.DictionaryDto;
+import com.numo.wordapp.service.dictionary.DictionaryCrawlingService;
 import com.numo.wordapp.service.dictionary.DictionaryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -17,10 +19,18 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DictionaryController {
     private final DictionaryService dictionaryService;
+    private final DictionaryCrawlingService dictionaryCrawlingService;
+
+    @Operation(summary = "사전 검색", description = "사전을 검색한다.")
+    @GetMapping("/list/{searchText}")
+    public ResponseEntity<List<DictionaryDto>> searchWordList(@PathVariable("searchText") String searchText) {
+        return ResponseEntity.ok(dictionaryService.search(searchText));
+    }
 
     @Operation(summary = "사전 검색", description = "사전을 검색한다.")
     @GetMapping("/{searchText}")
-    public ResponseEntity<List<DictionaryDto>> searchWord(@PathVariable("searchText") String searchText) {
-        return ResponseEntity.ok(dictionaryService.search(searchText));
+    public ResponseEntity<DictionaryCrawlingDto> searchWord(@PathVariable("searchText") String searchText) {
+        return ResponseEntity.ok(dictionaryCrawlingService.searchWord(searchText));
     }
+
 }

--- a/src/main/java/com/numo/wordapp/controller/DictionaryController.java
+++ b/src/main/java/com/numo/wordapp/controller/DictionaryController.java
@@ -1,8 +1,6 @@
 package com.numo.wordapp.controller;
 
-import com.numo.wordapp.dto.dictionary.DictionaryCrawlingDto;
 import com.numo.wordapp.dto.dictionary.DictionaryDto;
-import com.numo.wordapp.service.dictionary.DictionaryCrawlingService;
 import com.numo.wordapp.service.dictionary.DictionaryService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -19,18 +17,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DictionaryController {
     private final DictionaryService dictionaryService;
-    private final DictionaryCrawlingService dictionaryCrawlingService;
 
     @Operation(summary = "사전 검색", description = "사전을 검색한다.")
     @GetMapping("/list/{searchText}")
     public ResponseEntity<List<DictionaryDto>> searchWordList(@PathVariable("searchText") String searchText) {
-        return ResponseEntity.ok(dictionaryService.search(searchText));
+        return ResponseEntity.ok(dictionaryService.searchWordList(searchText));
     }
 
     @Operation(summary = "사전 검색", description = "사전을 검색한다.")
     @GetMapping("/{searchText}")
-    public ResponseEntity<DictionaryCrawlingDto> searchWord(@PathVariable("searchText") String searchText) {
-        return ResponseEntity.ok(dictionaryCrawlingService.searchWord(searchText));
+    public ResponseEntity<DictionaryDto> searchWord(@PathVariable("searchText") String searchText) {
+        return ResponseEntity.ok(dictionaryService.searchWord(searchText));
     }
 
 }

--- a/src/main/java/com/numo/wordapp/dto/dictionary/DaumDictionary.java
+++ b/src/main/java/com/numo/wordapp/dto/dictionary/DaumDictionary.java
@@ -4,6 +4,7 @@ import org.jsoup.nodes.Document;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class DaumDictionary implements DictionaryCrawling {
     private String dictUrl = "https://dic.daum.net/search.do";
@@ -11,12 +12,22 @@ public class DaumDictionary implements DictionaryCrawling {
 
     String wordXpath = "//*[@id='mArticle']/div[1]/div[2]/div[2]/div/div[1]/strong/a";
     String defXpath = "//*[@id=\"mArticle\"]/div[1]/div[2]/div[2]/div[1]/ul";
+    String defXpath2 = "//*[@id=\"mArticle\"]/div[1]/div[1]/div[2]/div/ul";
 
     @Override
     public DictionaryCrawlingDto getSearchWord(Document doc, String text) {
         String word = doc.selectXpath(wordXpath).text();
         String definition = doc.selectXpath(defXpath).text();
-        List<String> definitions = definitionToList(definition);
+        if (!definitionPatternMatch(definition)) {
+            definition = doc.selectXpath(defXpath2).text();
+        }
+
+        List<String> definitions = new ArrayList<>();
+        if (definition.isEmpty()) {
+            definition = null;
+        } else {
+            definitions = definitionToList(definition);
+        }
         return new DictionaryCrawlingDto(word, definition, definitions);
     }
 
@@ -30,4 +41,11 @@ public class DaumDictionary implements DictionaryCrawling {
         }
         return result;
     }
+
+    private boolean definitionPatternMatch(String definition) {
+        String patternString = "[0-9]+\\.[\\s가-힣.\\d~!@#$%^&*()_+\\[\\]\\;',/…]+";
+        return Pattern.matches(patternString, definition);
+    }
+
+
 }

--- a/src/main/java/com/numo/wordapp/dto/dictionary/DictionaryDto.java
+++ b/src/main/java/com/numo/wordapp/dto/dictionary/DictionaryDto.java
@@ -8,19 +8,23 @@ public record DictionaryDto(
         Long dictId,
         String word,
         String wordType,
-        String definition
+        String definition,
+        String mean
 ) {
     public static DictionaryDto of(Dictionary dictionary) {
         return DictionaryDto.builder()
                 .word(dictionary.getWord())
+                .mean(dictionary.getMean())
                 .build();
     }
 
-    public Dictionary toEntity(String definition) {
+    public Dictionary toEntity(String mean, String isCrawling) {
         return Dictionary.builder()
                 .word(word)
                 .wordType(wordType)
                 .definition(definition)
+                .mean(mean)
+                .isCrawling(isCrawling)
                 .build();
     }
 }

--- a/src/main/java/com/numo/wordapp/entity/dictionary/Dictionary.java
+++ b/src/main/java/com/numo/wordapp/entity/dictionary/Dictionary.java
@@ -3,6 +3,8 @@ package com.numo.wordapp.entity.dictionary;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.Objects;
+
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -16,4 +18,15 @@ public class Dictionary {
     private String wordType;
     @Column(columnDefinition="TEXT")
     private String definition;
+    private String mean;
+    private String isCrawling;
+
+    public boolean checkCrawling() {
+        return Objects.isNull(isCrawling);
+    }
+
+    public void updateMean(String mean) {
+        this.mean = mean;
+        this.isCrawling = "Y";
+    }
 }

--- a/src/main/java/com/numo/wordapp/repository/dictionary/DictionaryRepository.java
+++ b/src/main/java/com/numo/wordapp/repository/dictionary/DictionaryRepository.java
@@ -3,7 +3,10 @@ package com.numo.wordapp.repository.dictionary;
 import com.numo.wordapp.entity.dictionary.Dictionary;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 
 public interface DictionaryRepository extends JpaRepository<Dictionary, Long>, DictionaryCustomRepository {
     boolean existsByWord(String word);
+    Optional<Dictionary> findByWord(String word);
 }

--- a/src/main/java/com/numo/wordapp/service/dictionary/DictionaryService.java
+++ b/src/main/java/com/numo/wordapp/service/dictionary/DictionaryService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +25,37 @@ public class DictionaryService {
         return score.isNaN();
     }
 
-    public List<DictionaryDto> search(String searchText) {
+    public DictionaryDto searchWord(String searchText) {
+        Optional<Dictionary> dictWord = dictionaryRepository.findByWord(searchText);
+        // 해당하는 데이터가 없으면
+        if (dictWord.isEmpty()) {
+            Dictionary crawlingWord = getCrawlingWord(searchText);
+            return DictionaryDto.of(dictionaryRepository.save(crawlingWord));
+        }
+
+        // 뜻 데이터가 없다면 크롤링해와서 넣어준다.
+        Dictionary dictionary = dictWord.get();
+        if (dictionary.checkCrawling()) {
+            Dictionary crawlingWord = getCrawlingWord(searchText);
+            dictionary.updateMean(crawlingWord.getMean());
+            return DictionaryDto.of(dictionaryRepository.save(dictionary));
+        }
+
+        return DictionaryDto.of(dictionary);
+    }
+
+    private Dictionary getCrawlingWord(String searchText) {
+        DictionaryCrawlingDto dictionaryCrawlingDto = dictionaryCrawlingService.searchWord(searchText);
+        String mean = String.join(",", dictionaryCrawlingDto.definitions());
+        Dictionary saveDict = Dictionary.builder()
+                .word(searchText)
+                .mean(mean)
+                .isCrawling("Y")
+                .build();
+        return saveDict;
+    }
+
+    public List<DictionaryDto> searchWordList(String searchText) {
         List<DictionaryDto> res = null;
         int limit = 5;
         List<String> cacheWords = dictionaryCacheService.search(key, searchText, limit);
@@ -50,11 +81,13 @@ public class DictionaryService {
         DictionaryCrawlingDto resultDto = dictionaryCrawlingService.searchWord(dictionaryDto.word());
 
         // 실제 사전에 등록이 되어있지 않으면 사전 데이터베이스에 저장하지 않는다.
-        if (!Objects.equals(resultDto.word(), dictionaryDto.word().toLowerCase())) {
+        if (!Objects.equals(resultDto.word().toLowerCase(), dictionaryDto.word().toLowerCase())) {
             return null;
         }
 
-        Dictionary dictionary = dictionaryDto.toEntity(resultDto.definition());
+        String mean = String.join(",", resultDto.definitions());
+
+        Dictionary dictionary = dictionaryDto.toEntity(mean, "Y");
         return DictionaryDto.of(dictionaryRepository.save(dictionary));
     }
 }

--- a/src/test/java/com/numo/wordapp/test/jsoup/JsoupTest.java
+++ b/src/test/java/com/numo/wordapp/test/jsoup/JsoupTest.java
@@ -1,4 +1,4 @@
-package jsoup;
+package com.numo.wordapp.test.jsoup;
 
 import org.jsoup.Connection;
 import org.jsoup.Jsoup;
@@ -7,6 +7,8 @@ import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.ObjectUtils;
+
+import java.util.regex.Pattern;
 
 public class JsoupTest {
     public static Connection getJsoupConnection(String url) throws Exception {
@@ -22,7 +24,7 @@ public class JsoupTest {
 
     @Test
     void start() throws Exception {
-        String word = "Exception";
+        String word = "efface";
         String url = "https://dic.daum.net/search.do?q=${word}".replace("${word}", word);
 
         Document doc = JsoupTest.getJsoupConnection(url).get();
@@ -30,11 +32,29 @@ public class JsoupTest {
         System.out.println(doc.title());
 
         String wordXpath = "//*[@id='mArticle']/div[1]/div[2]/div[2]/div/div[1]/strong/a";
-        String defXpath = "//*[@id=\"mArticle\"]/div[1]/div[2]/div[2]/div[1]/ul";
+        String defXpath = "//*[@id='mArticle']/div[1]/div[2]/div[2]/div/ul";
+
+
+        //*[@id="mArticle"]/div[1]/div[2]/div[2]/div/ul
+        // 위에꺼가 뜻이 매칭이 안된다면 아래꺼 시도
+        //*[@id="mArticle"]/div[1]/div[1]/div[2]/div/ul
 
         String result = doc.selectXpath(wordXpath).text();
         String definition = doc.selectXpath(defXpath).text();
 
+        System.out.println(result);
+        System.out.println(definition);
+
         Assertions.assertEquals(word.toLowerCase(), result);
+    }
+
+    @Test
+    void regexTest() {
+        String mean = "1.안녕하세요2.안부3.여보세요.";
+        String mean2 = "remove completely from recognition or memory";
+
+        String patternString = "[0-9]+\\.[\\s가-힣.\\d~!@#$%^&*()_+\\[\\]\\;',/]+";
+        System.out.println(Pattern.matches(patternString, mean));
+        System.out.println(Pattern.matches(patternString, mean2));
     }
 }


### PR DESCRIPTION
#28 

before: 자동완성 단어를 선택하면 해당 단어만 출력

after: 자동완성 단어 선택 시 사전을 검색하여 뜻 데이터 출력
* 뜻 데이터는 먼저 사전 db를 확인해보고 없다면 다음 사전의 데이터를 가져와 저장
* 한번 다음 사전의 데이터를 가져온 적이 있으면 사전 db의 데이터만 출력
* 다음 사전에서 xpath가 여러개 있는 관계로 해당하는 문자열에 매칭이 안되면(영영사전) 다음 xpath를 확인하도록 함