### PR TITLE
feat: 단어 단건 조회 기능 추가

### DIFF
--- a/http/word.http
+++ b/http/word.http
@@ -4,7 +4,8 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 {
-  "word": "Pneumonoultram",
+  "folderId": 6,
+  "word": "rasdf",
   "mean": "mean",
   "read": "read",
   "memo": "memo",
@@ -27,6 +28,11 @@ Authorization: Bearer {{accessToken}}
 > {%
     client.global.set("wordId", response.body.wordId)
 %}
+
+### 해당 단어 조회
+GET localhost:8088/api/word/item/89
+Content-Type: application/json
+Authorization: Bearer {{accessToken}}
 
 ### 단어 조회
 GET localhost:8088/api/word?current=1&lastWordId=62

--- a/src/main/java/com/numo/wordapp/controller/WordController.java
+++ b/src/main/java/com/numo/wordapp/controller/WordController.java
@@ -38,11 +38,19 @@ public class WordController {
 
     @Operation(summary = "단어 조회", description = "단어를 조회한다.")
     @GetMapping
-    public ResponseEntity<ReadWordListResponseDto> getWord(@AuthenticationPrincipal UserDetailsImpl user,
+    public ResponseEntity<ReadWordListResponseDto> getWords(@AuthenticationPrincipal UserDetailsImpl user,
                                                            PageRequestDto page,
                                                            ReadWordRequestDto readDto) {
         Long userId = user.getUserId();
         return ResponseEntity.ok(wordService.getWord(userId, page, readDto));
+    }
+
+    @Operation(summary = "단어 단건 조회", description = "해당하는 단어를 조회한다.")
+    @GetMapping("/item/{wordId}")
+    public ResponseEntity<ReadWordResponseDto> getWord(@AuthenticationPrincipal UserDetailsImpl user,
+                                                       @PathVariable("wordId") Long wordId) {
+        Long userId = user.getUserId();
+        return ResponseEntity.ok(wordService.getWord(userId, wordId));
     }
 
     @Operation(summary = "단어 저장", description = "단어를 저장한다.")

--- a/src/main/java/com/numo/wordapp/repository/word/WordCustomRepository.java
+++ b/src/main/java/com/numo/wordapp/repository/word/WordCustomRepository.java
@@ -19,6 +19,9 @@ public interface WordCustomRepository {
      */
     Slice<WordDto> findWordBy(Pageable pageable, Long userId, Long lastWordId, ReadWordRequestDto readDto);
     DailyWordListDto findDailyWordBy(Long userId, List<String> words);
+
+    WordDto findWordByWordId(Long userId, Long wordId);
+
     List<WordDetailResponseDto> findWordDetailByIds(List<Long> wordIds);
     List<FolderInWordCountDto> countFolderInWord(Long userId);
 }

--- a/src/main/java/com/numo/wordapp/repository/word/WordCustomRepositoryImpl.java
+++ b/src/main/java/com/numo/wordapp/repository/word/WordCustomRepositoryImpl.java
@@ -79,6 +79,38 @@ public class WordCustomRepositoryImpl implements WordCustomRepository {
         return checkLastPage(pageable, results);
     }
 
+    /**
+     * wordId에 해당하는 단어 데이터를 찾는다
+     * @param userId 유저 아이디
+     * @param wordId 단어 고유 번호
+     * @return wordId에 해당하는 단어 데이터
+     */
+    @Override
+    public WordDto findWordByWordId(Long userId, Long wordId) {
+        return queryFactory.select(Projections.constructor(
+                        WordDto.class,
+                        qWord.wordId,
+                        qWord.folder.folderId,
+                        qWord.word,
+                        qWord.mean,
+                        qWord.read,
+                        qWord.memo,
+                        qWord.sound.word,
+                        qWord.memorization,
+                        qWord.lang,
+                        qWord.updateTime,
+                        qWord.createTime
+                ))
+                .from(qWord)
+                .leftJoin(qWord.folder)
+                .leftJoin(qWord.sound)
+                .leftJoin(qWord.user)
+                .where(
+                        qWord.wordId.eq(wordId),
+                        qWord.user.userId.eq(userId)
+                ).fetchOne();
+    }
+
     @Override
     public List<WordDetailResponseDto> findWordDetailByIds(List<Long> wordIds) {
         List<WordDetailResponseDto> results = queryFactory.select(Projections.constructor(

--- a/src/main/java/com/numo/wordapp/service/word/WordService.java
+++ b/src/main/java/com/numo/wordapp/service/word/WordService.java
@@ -135,6 +135,13 @@ public class WordService {
         return new ReadWordListResponseDto(dto, pageResponse);
     }
 
+    public ReadWordResponseDto getWord(Long userId, Long wordId) {
+        WordDto wordDto = wordRepository.findWordByWordId(userId, wordId);
+        List<WordDetailResponseDto> wordDetails = wordRepository.findWordDetailByIds(List.of(wordId));
+        List<ReadWordDetailListResponseDto> detailGroups = WordDetailResponseDto.grouping(wordDetails);
+        return ReadWordResponseDto.of(wordDto, detailGroups);
+    }
+
     /**
      * 단어 상세 데이터 리스트에서 단어와 연관된 단어 상세 데이터를 찾는다.
      * @param wordId 단어 고유번호


### PR DESCRIPTION
단건으로 조회하는 요청 사항이 추가됨에 따라 단건 조회 기능 추가

이미 GET으로된 `word/{text}` 인 search API가 있기에 부득이하게 url을 `/word/item/{wordId}`로 설정