### PR TITLE
fix: 퀴즈 수정(배치 쿼리, 통계 조회 데이터 추가)

### DIFF
--- a/module-api/http/quiz.http
+++ b/module-api/http/quiz.http
@@ -5,7 +5,7 @@ Authorization: Bearer {{accessToken}}
 
 {
   "folderId": 6,
-  "type": "multipleChoice",
+  "type": "word",
   "sort": "random",
   "memorization": "",
   "count": 5

--- a/module-api/http/quiz_stat.http
+++ b/module-api/http/quiz_stat.http
@@ -1,10 +1,10 @@
 ### 퀴즈 통계 생성
-POST localhost:8088/api/quiz-stat/14
-Content-Type: application/json
+POST localhost:8088/api/quiz-stat/25
+Content-Type: application/jsonR
 Authorization: Bearer {{accessToken}}
 
 ### 퀴즈 통계 조회
-GET localhost:8088/api/quiz-stat/14
+GET localhost:8088/api/quiz-stat/25
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
@@ -14,7 +14,7 @@ Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 
 ### 퀴즈 통계 삭제
-DELETE localhost:8088/api/quiz-stat/4
+DELETE localhost:8088/api/quiz-stat/14
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 

--- a/module-api/src/main/java/com/numo/api/domain/quiz/dto/stat/QuizStatResponseDto.java
+++ b/module-api/src/main/java/com/numo/api/domain/quiz/dto/stat/QuizStatResponseDto.java
@@ -9,14 +9,15 @@ import java.time.LocalDateTime;
 @Builder
 public record QuizStatResponseDto(
         Long quizStatId,
+        String folderName,
         int totalCount,
         int correctCount,
         int wrongCount,
         String createTime,
         String updateTime
 ) {
-    public QuizStatResponseDto(Long quizStatId, int totalCount, int correctCount, int wrongCount, LocalDateTime createTime, LocalDateTime updateTime) {
-        this(quizStatId, totalCount, correctCount, wrongCount, Timestamped.getFormatTime(createTime, "yyyy-MM-dd hh:mm:ss"), Timestamped.getFormatTime(updateTime, "yyyy-MM-dd hh:mm:ss"));
+    public QuizStatResponseDto(Long quizStatId, String folderName, int totalCount, int correctCount, int wrongCount, LocalDateTime createTime, LocalDateTime updateTime) {
+        this(quizStatId, folderName, totalCount, correctCount, wrongCount, Timestamped.getFormatTime(createTime, "yyyy-MM-dd hh:mm:ss"), Timestamped.getFormatTime(updateTime, "yyyy-MM-dd hh:mm:ss"));
     }
 
     public static QuizStatResponseDto of(QuizStat quizStat) {

--- a/module-api/src/main/java/com/numo/api/domain/quiz/repository/query/QuizStatQueryRepository.java
+++ b/module-api/src/main/java/com/numo/api/domain/quiz/repository/query/QuizStatQueryRepository.java
@@ -3,8 +3,11 @@ package com.numo.api.domain.quiz.repository.query;
 import com.numo.api.domain.quiz.dto.stat.QuizStatResponseDto;
 import com.numo.api.global.comm.date.DateCondition;
 import com.numo.api.global.comm.date.DateRequestDto;
+import com.numo.api.global.comm.exception.CustomException;
+import com.numo.api.global.comm.exception.ErrorCode;
 import com.numo.domain.quiz.QQuizStat;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -18,10 +21,19 @@ public class QuizStatQueryRepository {
 
     QQuizStat qQuizStat = QQuizStat.quizStat;
 
-    public List<QuizStatResponseDto> findQuizStatList(Long userId, DateRequestDto dateRequest) {
+    public QuizStatResponseDto findQuiz(Long quizStatId, Long userId, DateRequestDto dateRequest) {
+        List<QuizStatResponseDto> result = findQuizStatList(quizStatId, userId, dateRequest);
+        if (result.isEmpty()) {
+            throw new CustomException(ErrorCode.DATA_NOT_FOUND);
+        }
+        return result.get(0);
+    }
+
+    public List<QuizStatResponseDto> findQuizStatList(Long quizStatId, Long userId, DateRequestDto dateRequest) {
         return jpaQueryFactory.select(Projections.constructor(
                         QuizStatResponseDto.class,
                         qQuizStat.id,
+                        qQuizStat.quizInfo.folder.folderName,
                         qQuizStat.totalCount,
                         qQuizStat.correctCount,
                         qQuizStat.wrongCount,
@@ -29,9 +41,17 @@ public class QuizStatQueryRepository {
                         qQuizStat.updateTime
                 )).from(qQuizStat)
                 .where(
+                        quizStatIdEq(quizStatId),
                         qQuizStat.user.userId.eq(userId),
                         DateCondition.createDateCondition(qQuizStat.baseDate, dateRequest)
                 ).fetch();
+    }
+
+    private BooleanExpression quizStatIdEq(Long quizStatId) {
+        if (quizStatId == null) {
+            return null;
+        }
+        return qQuizStat.id.eq(quizStatId);
     }
 
 }

--- a/module-api/src/main/java/com/numo/api/domain/quiz/service/QuizStatService.java
+++ b/module-api/src/main/java/com/numo/api/domain/quiz/service/QuizStatService.java
@@ -61,8 +61,7 @@ public class QuizStatService {
      * @return 퀴즈 통계 데이터
      */
     public QuizStatResponseDto getQuizStat(Long quizStatId, Long userId) {
-        QuizStat quizStat = quizStatRepository.findQuizStatByIdAndUserId(quizStatId, userId);
-        return QuizStatResponseDto.of(quizStat);
+        return quizStatQueryRepository.findQuiz(quizStatId, userId, null);
     }
 
     /**
@@ -72,7 +71,7 @@ public class QuizStatService {
      * @return 퀴즈 통계 리스트
      */
     public List<QuizStatResponseDto> getQuizStatList(Long userId, DateRequestDto dateRequest) {
-        return quizStatQueryRepository.findQuizStatList(userId, dateRequest);
+        return quizStatQueryRepository.findQuizStatList(null, userId, dateRequest);
     }
 
     /**

--- a/module-api/src/main/java/com/numo/api/global/comm/date/DateCondition.java
+++ b/module-api/src/main/java/com/numo/api/global/comm/date/DateCondition.java
@@ -7,6 +7,10 @@ import com.querydsl.core.types.dsl.Expressions;
 public class DateCondition {
 
     public static BooleanExpression createDateCondition(QBaseDate qDate, DateRequestDto dateRequest) {
+        if (dateRequest == null) {
+            return null;
+        }
+
         BooleanExpression result = Expressions.asString("1").eq("1");
         Integer year = dateRequest.year();
         Integer month = dateRequest.month();

--- a/module-domain/src/main/java/com/numo/domain/dictionary/Dictionary.java
+++ b/module-domain/src/main/java/com/numo/domain/dictionary/Dictionary.java
@@ -18,6 +18,7 @@ public class Dictionary {
     private String wordType;
     @Column(columnDefinition="TEXT")
     private String definition;
+    @Column(columnDefinition="TEXT")
     private String mean;
     private String isCrawling;
 

--- a/module-domain/src/main/java/com/numo/domain/quiz/repository/QuizJdbcRepository.java
+++ b/module-domain/src/main/java/com/numo/domain/quiz/repository/QuizJdbcRepository.java
@@ -15,11 +15,13 @@ public class QuizJdbcRepository {
 
     /**
      * 7일이 지난 퀴즈 데이터를 삭제한다
+     * 완료된 퀴즈 데이터만 삭제 (이어하기 데이터는 삭제하지 않음)
      */
     public void deleteQuiz() {
         String sql = "DELETE q FROM quiz q " +
                 "INNER JOIN quiz_info qi ON q.quiz_info_id = qi.quiz_info_id " +
-                "WHERE qi.create_time > NOW() - INTERVAL 7 DAY; ";
+                "WHERE qi.complete = true " +
+                " and qi.update_time < NOW() - INTERVAL 7 DAY;";
         jdbcTemplate.update(sql);
     }
 }


### PR DESCRIPTION
* 퀴즈 삭제 배치 쿼리 수정
  * 7일 이전에 해당하는 퀴즈 데이터를 삭제하도록 되어있어 쿼리 수정
  * 퀴즈 이어하기를 위해 완료된 퀴즈 데이터만 삭제하도록 수정
* 퀴즈 통계 조회 폴더명 데이터 추가
* 사전 뜻 필드 길이 초과로 text로 타입 변경