### PR TITLE
fix: 사전 뜻 데이터가 한 개일 때 뜻을 제대로 저장하지 못하는 이슈 수정

### DIFF
--- a/module-api/http/dict.http
+++ b/module-api/http/dict.http
@@ -1,5 +1,5 @@
 ### 사전 조회
-GET localhost:8088/api/dict/exception
+GET localhost:8088/api/dict/stay in shape
 Content-Type: application/json
 Authorization: Bearer {{accessToken}}
 

--- a/module-api/src/test/java/com/numo/api/test/jsoup/JsoupTest.java
+++ b/module-api/src/test/java/com/numo/api/test/jsoup/JsoupTest.java
@@ -24,7 +24,7 @@ public class JsoupTest {
 
     @Test
     void start() throws Exception {
-        String word = "efface";
+        String word = "vandalize";
         String url = "https://dic.daum.net/search.do?q=${word}".replace("${word}", word);
 
         Document doc = JsoupTest.getJsoupConnection(url).get();
@@ -32,7 +32,10 @@ public class JsoupTest {
         System.out.println(doc.title());
 
         String wordXpath = "//*[@id='mArticle']/div[1]/div[2]/div[2]/div/div[1]/strong/a";
-        String defXpath = "//*[@id='mArticle']/div[1]/div[2]/div[2]/div/ul";
+//        String defXpath = "//*[@id='mArticle']/div[1]/div[2]/div[2]/div/ul";
+
+        String defXpath = "//*[@id=\"mArticle\"]/div[1]/div[2]/div[2]/div[1]/ul";
+        String defXpath2 = "//*[@id=\"mArticle\"]/div[1]/div[1]/div[2]/div/ul";
 
 
         //*[@id="mArticle"]/div[1]/div[2]/div[2]/div/ul
@@ -41,10 +44,11 @@ public class JsoupTest {
 
         String result = doc.selectXpath(wordXpath).text();
         String definition = doc.selectXpath(defXpath).text();
+        String definition2 = doc.selectXpath(defXpath).text();
 
         System.out.println(result);
         System.out.println(definition);
-
+        System.out.println(definition2);
         Assertions.assertEquals(word.toLowerCase(), result);
     }
 


### PR DESCRIPTION
* 사전 뜻 데이터가 한 개일 때는 1. 2. 가 붙지 않고 그냥 문자열만 붙어서 나오므로 해당 문제 수정