### PR TITLE
fix: 문장 연관 단어 저장 시 중복된 단어 데이터가 있으면 태그 문자열이 제대로 저장 안되는 오류 수정

### DIFF
--- a/module-api/src/main/java/com/numo/api/domain/dailySentence/DailySentenceService.java
+++ b/module-api/src/main/java/com/numo/api/domain/dailySentence/DailySentenceService.java
@@ -187,10 +187,11 @@ public class DailySentenceService {
      * @param sentence 문장
      * @return 연관 단어에 태그가 추가된 문장 문자열
      */
-    private String addTag(List<String> words, String sentence) {
+    public String addTag(List<String> words, String sentence) {
         String result = sentence;
+        List<String> uniqueWords = new HashSet<>(words).stream().toList();
 
-        for (String word : words) {
+        for (String word : uniqueWords) {
             // -로 붙어있는 문자열은 같은 단어로 취급하지 않고 전체가 동일해야 한다.
             String regex = "(?<!-)\\b" + Pattern.quote(word) + "\\b(?!-)";
             Pattern pattern = Pattern.compile(regex);


### PR DESCRIPTION
* 문장 저장 시 단어장에 동일한 단어가 있으면 태그 문자열에 strong이 1개 이상 붙여지는 문제 수정